### PR TITLE
Update Xamarin.Essentials to 1.0.0

### DIFF
--- a/Plugin.Jobs/Platforms/Shared/Extensions.cs
+++ b/Plugin.Jobs/Platforms/Shared/Extensions.cs
@@ -19,7 +19,7 @@ namespace Plugin.Jobs
             }
 
             var inetAvail = Connectivity.NetworkAccess == NetworkAccess.Internet;
-            var wifi = Connectivity.Profiles.Contains(ConnectionProfile.WiFi);
+            var wifi = Connectivity.ConnectionProfiles.Contains(ConnectionProfile.WiFi);
             if (job.RequiredNetwork == NetworkType.Any && !inetAvail)
                 return false;
 

--- a/Plugin.Jobs/Plugin.Jobs.csproj
+++ b/Plugin.Jobs/Plugin.Jobs.csproj
@@ -59,19 +59,19 @@ Supported Platforms
     </ItemGroup>
 
     <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
-        <PackageReference Include="Xamarin.Essentials" Version="0.10.0-preview" />
+        <PackageReference Include="Xamarin.Essentials" Version="1.0.0" />
         <Compile Include="Platforms\Android\**\*.cs" />
         <Compile Include="Platforms\Shared\**\*.cs" />
     </ItemGroup>
 
     <ItemGroup Condition=" $(TargetFramework.StartsWith('Xamarin.iOS')) ">
-        <PackageReference Include="Xamarin.Essentials" Version="0.10.0-preview" />
+        <PackageReference Include="Xamarin.Essentials" Version="1.0.0" />
         <Compile Include="Platforms\iOS\**\*.cs" />
         <Compile Include="Platforms\Shared\**\*.cs" />
     </ItemGroup>
 
     <ItemGroup Condition=" $(TargetFramework.StartsWith('uap')) ">
-        <PackageReference Include="Xamarin.Essentials" Version="0.10.0-preview" />
+        <PackageReference Include="Xamarin.Essentials" Version="1.0.0" />
         <Compile Include="Platforms\Uwp\**\*.cs" />
         <Compile Include="Platforms\Shared\**\*.cs" />
     </ItemGroup>

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# ACR Background Jobs Plugin Plugin for Xamarin & Windows
+# ACR Background Jobs Plugin for Xamarin & Windows
 
 [Change Log - October 22, 2018](changelog.md)
 ### [SUPPORT THIS PROJECT](https://github.com/aritchie/home)


### PR DESCRIPTION
There is a breaking change for Xamarin.Essentials 1.0.0 which is resolved with this PR.